### PR TITLE
Added button that allows people get built application in their devices from browser

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,10 @@ Each thumbnail image view may have its own transform, the focus and defocus anim
 
 Works on iPhone and iPad.
 
+<div class="macbuildserver-block">
+    <a class="macbuildserver-button" href="http://macbuildserver.com/project/github/build/?xcode_project=Example%2FASMediaFocusExemple.xcodeproj&amp;target=ASMediaFocusExemple&amp;repo_url=https%3A%2F%2Fgithub.com%2Fautresphere%2FASMediaFocusManager&amp;build_conf=Release" target="_blank"><img src="http://com.macbuildserver.github.s3-website-us-east-1.amazonaws.com/button_up.png"/></a><br/><sup><a href="http://macbuildserver.com/github/opensource/" target="_blank">by MacBuildServer</a></sup>
+</div>
+
 ![](https://github.com/autresphere/ASMediaFocusManager/raw/master/Screenshots/video.gif) 
 
 ## Orientation


### PR DESCRIPTION
Hey,

I've added 'Install app' button into your README file. Anyone could try your sample application right in browser. Look how it's working!

To learn more, please look at: http://macbuildserver.com/github/opensource/
