### PR TITLE
isDefocusingWithTap is now public

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -42,6 +42,8 @@
 @property (nonatomic, assign) BOOL zoomEnabled;
 // Returns whether gesture is disabled during zooming. Defaults to YES.
 @property (nonatomic, assign) BOOL gestureDisabledDuringZooming;
+// Returns whether defocuses with tap. Defaults to NO.
+@property (nonatomic) BOOL isDefocusingWithTap;
 
 - (void)installOnViews:(NSArray *)views;
 - (void)installOnView:(UIView *)view;

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -19,7 +19,6 @@ static CGFloat const kAnimationDuration = 0.5;
 @property (nonatomic, strong) UIView *mediaView;
 @property (nonatomic, strong) ASMediaFocusController *focusViewController;
 @property (nonatomic) BOOL isZooming;
-@property (nonatomic) BOOL isDefocusingWithTap;
 @end
 
 @implementation ASMediaFocusManager


### PR DESCRIPTION
I wasn't able to hide the 'done' button and defocus by clicking the enlarged view. This should fix that.

In my case:
`focusManager = [[ASMediaFocusManager alloc] init];
focusManager.delegate = self;
focusManager.isDefocusingWithTap = YES;`
