### PR TITLE
Allow single tap exit & double tap zoom to coexist

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusController.h
+++ b/ASMediaFocusManager/ASMediaFocusController.h
@@ -16,6 +16,7 @@
 @property (strong, nonatomic) IBOutlet UIView *contentView;
 @property (strong, nonatomic) IBOutlet UILabel *titleLabel;
 @property (strong, nonatomic) UIView *accessoryView;
+@property (strong, nonatomic) UITapGestureRecognizer *doubleTapGesture;
 
 - (void)updateOrientationAnimated:(BOOL)animated;
 - (void)installZoomView;

--- a/ASMediaFocusManager/ASMediaFocusController.m
+++ b/ASMediaFocusManager/ASMediaFocusController.m
@@ -19,6 +19,16 @@ static NSTimeInterval const kDefaultOrientationAnimationDuration = 0.4;
 
 @implementation ASMediaFocusController
 
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) {
+        self.doubleTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
+        self.doubleTapGesture.numberOfTapsRequired = 2;
+    }
+
+    return self;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
@@ -164,7 +174,6 @@ static NSTimeInterval const kDefaultOrientationAnimationDuration = 0.4;
 - (void)installZoomView
 {
     ASImageScrollView *scrollView;
-    UITapGestureRecognizer *tapGesture;
     
     scrollView = [[ASImageScrollView alloc] initWithFrame:self.contentView.bounds];
     scrollView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
@@ -173,9 +182,7 @@ static NSTimeInterval const kDefaultOrientationAnimationDuration = 0.4;
     [scrollView displayImage:self.mainImageView.image];
     self.mainImageView.hidden = YES;
     
-    tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
-    tapGesture.numberOfTapsRequired = 2;
-    [self.scrollView addGestureRecognizer:tapGesture];
+    [self.scrollView addGestureRecognizer:self.doubleTapGesture];
 }
 
 - (void)uninstallZoomView

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -126,6 +126,7 @@ static CGFloat const kAnimationDuration = 0.5;
             UITapGestureRecognizer *tapGesture;
 
             tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDefocusGesture:)];
+            [tapGesture requireGestureRecognizerToFail:focusViewController.doubleTapGesture];
             [focusViewController.view addGestureRecognizer:tapGesture];
         }
         else


### PR DESCRIPTION
By exposing the double tap recognizer, we can require the single tap recognizer to require the double tap recognizer to fail. This allows the double tap zoom feature to still work even when the user has enabled single tap closing. I made this solution for my project but figured I'd offer it as a pull request if you want it.
