### PR TITLE
Update delegate property attribute from assign to weak

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -38,7 +38,7 @@
 
 @interface ASMediaFocusManager : NSObject
 
-@property (nonatomic, assign) id<ASMediasFocusDelegate> delegate;
+@property (nonatomic, weak) id<ASMediasFocusDelegate> delegate;
 // The animation duration. Defaults to 0.5.
 @property (nonatomic, assign) NSTimeInterval animationDuration;
 // The background color. Defaults to transparent black.


### PR DESCRIPTION
ASMediaFocusManager has been crashing for us on line 321 of ASMediaFocusManager.m with EXC_BAD_ACCESS KERN_INVALID_ADDRESS. The property `delegate` currently has the `assign` attribute which means that if it's deallocated, we are left with a dangling pointer under ARC. This pull request changes the property to `weak`. (This reasoning based on the "Property Attributes" of [Apple's ARC transition docs](https://developer.apple.com/library/ios/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html).)
