### PR TITLE
Fixed occasional gesture lag

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusController.m
+++ b/ASMediaFocusManager/ASMediaFocusController.m
@@ -213,7 +213,7 @@ static NSTimeInterval const kDefaultOrientationAnimationDuration = 0.4;
     
     [UIView animateWithDuration:0.5
                           delay:0
-                        options:UIViewAnimationOptionBeginFromCurrentState
+                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
                      animations:^{
                          self.accessoryView.alpha = (visible?1:0);
                      }


### PR DESCRIPTION
When the full screen view is opened, occasionally it will be unresponsive to gestures that are submitted quickly after opening (e.g. double tap or pinch to zoom). This issue was caused by accessory view animation not allowing UserInteraction. Saw debug log messages like this every time the issue was reproduced:
````
Gesture: Failed to receive system gesture state notification before next touch
Failed to receive system gesture state notification before next touch
````