### PR TITLE
Added ability to load from cached image if exists.

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -32,6 +32,8 @@
 - (void)mediaFocusManagerWillDisappear:(ASMediaFocusManager *)mediaFocusManager;
 // Called when the view has be dismissed by the 'done' button or by gesture.
 - (void)mediaFocusManagerDidDisappear:(ASMediaFocusManager *)mediaFocusManager;
+// Called before mediaURLForView to check if image is already on memory.
+- (UIImage*)mediaFocusManager:(ASMediaFocusManager*)mediaFocusManager cachedImageForView:(UIView*)view;
 
 @end
 

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -155,6 +155,13 @@ static CGFloat const kAnimationDuration = 0.5;
     viewController.mainImageView.image = image;
     viewController.mainImageView.contentMode = imageView.contentMode;
     
+    if ([self.delegate respondsToSelector:@selector(mediaFocusManager:cachedImageForView:)]) {
+        UIImage *image = [self.delegate mediaFocusManager:self cachedImageForView:mediaView];
+        if (image) {
+            viewController.mainImageView.image = image;
+            return viewController;
+        }
+    }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSURL *url;
         NSData *data;


### PR DESCRIPTION
We have an app that loads and caches images in background. To utilize this in ASMediaFocusManager, an ability to load from cached image before asking remote URL and fetching it, will be good.