### PR TITLE
Fixed application crash if image = nil

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -241,7 +241,15 @@ static CGFloat const kSwipeOffset = 100;
         NSError *error = nil;
         
         url = [self.delegate mediaFocusManager:self mediaURLForView:mediaView];
-        data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+        
+        if (url) {
+            data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+        }else{
+            NSMutableDictionary* details = [NSMutableDictionary dictionary];
+            [details setValue:@"image = nil" forKey:NSLocalizedDescriptionKey];
+            error = [NSError errorWithDomain:@"Image Error" code:200 userInfo:details];
+        }
+        
         if(error != nil)
         {
             NSLog(@"Warning: Unable to load image at %@. %@", url, error);

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -245,9 +245,8 @@ static CGFloat const kSwipeOffset = 100;
         if (url) {
             data = [NSData dataWithContentsOfURL:url options:0 error:&error];
         }else{
-            NSMutableDictionary* details = [NSMutableDictionary dictionary];
-            [details setValue:@"image = nil" forKey:NSLocalizedDescriptionKey];
-            error = [NSError errorWithDomain:@"Image Error" code:200 userInfo:details];
+            NSLog(@"Warning: url is nil");
+            return;
         }
         
         if(error != nil)


### PR DESCRIPTION
if the image url returned by the delegate was nil the app would crash if the following error.

Fatal Exception: NSInvalidArgumentException
*** -[_NSPlaceholderData initWithContentsOfURL:options:error:]: nil URL argument

now if the url = nil it will throw an warning with the error message saying that img = nil.

this way the app wont crash.