### PR TITLE
Animate cornerRadius

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -332,6 +332,7 @@ static CGFloat const kSwipeOffset = 100;
     imageView.center = center;
     imageView.transform = mediaView.transform;
     imageView.bounds = mediaView.bounds;
+    imageView.layer.cornerRadius = mediaView.layer.cornerRadius;
     
     self.isZooming = YES;
     
@@ -389,6 +390,10 @@ static CGFloat const kSwipeOffset = 100;
                          [imageView.layer removeAllAnimations];
                          imageView.transform = CGAffineTransformIdentity;
                          imageView.frame = frame;
+
+                         if (mediaView.layer.cornerRadius > 0) {
+                             [self animateCornerRadiusOfView:imageView withDuration:duration from:mediaView.layer.cornerRadius to:0.0f];
+                         }
                      }
                      completion:^(BOOL finished) {
                          [UIView animateWithDuration:(self.elasticAnimation?self.animationDuration*kAnimateElasticDurationRatio/3:0)
@@ -425,6 +430,16 @@ static CGFloat const kSwipeOffset = 100;
                                                                }];
                                           }];
                      }];
+}
+
+- (void)animateCornerRadiusOfView:(UIView *)view withDuration:(NSTimeInterval)duration from:(float)initialValue to:(float)finalValue {
+    CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"cornerRadius"];
+    animation.timingFunction = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+    animation.fromValue = [NSNumber numberWithFloat:initialValue];
+    animation.toValue = [NSNumber numberWithFloat:finalValue];
+    animation.duration = duration;
+    [view.layer setCornerRadius:finalValue];
+    [view.layer addAnimation:animation forKey:@"cornerRadius"];
 }
 
 - (void)updateAnimatedView:(UIView *)view fromFrame:(CGRect)initialFrame toFrame:(CGRect)finalFrame
@@ -480,6 +495,11 @@ static CGFloat const kSwipeOffset = 100;
                      }];
     
     duration = (self.elasticAnimation?self.animationDuration*(1-kAnimateElasticDurationRatio):self.animationDuration);
+    
+    if (self.mediaView.layer.cornerRadius > 0) {
+        [self animateCornerRadiusOfView:contentView withDuration:duration from:0.0f to:self.mediaView.layer.cornerRadius];
+    }
+    
     [UIView animateWithDuration:duration
                           delay:0
                         options:0


### PR DESCRIPTION
Makes the focus view animate the cornerRadius from the value on the original view to 0 and then from 0 to the original value, so it doesn't jump between having a cornerRadius and being square. This is particularly noticeable when going from focus to unfocused.

https://dl.dropboxusercontent.com/u/67484/cornerRadius.mov

Not sure if it's the most correct way of doing this but seems to work.

