### PR TITLE
Support for swiping between multiple photos/videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 *.mode2v3
 *.xcworkspace
 xcuserdata
+Pods
+

--- a/ASMediaFocusManager.podspec
+++ b/ASMediaFocusManager.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.platform = :ios, '6.0'
   s.source_files = 'ASMediaFocusManager/*.{h,m}'
-  s.resources = ['ASMediaFocusManager/*.xib', 'ASMediaFocusManager/Resources/*.png']
+  s.resource_bundle = { 'ASMediaFocusManager' => ['ASMediaFocusManager/*.xib', 'ASMediaFocusManager/Resources/*.png'] }
   s.frameworks = 'UIKit', 'Foundation', 'CoreGraphics', 'AVFoundation'
   s.requires_arc = true
   s.dependency 'ASBPlayerScrubbing', '~> 0.1'

--- a/ASMediaFocusManager/ASImageScrollView.m
+++ b/ASMediaFocusManager/ASImageScrollView.m
@@ -122,17 +122,19 @@
     if(self.zoomImageView == nil)
     {
         self.zoomScale = 1.0;
-        
+
         // make a new UIImageView for the new image
         self.zoomImageView = [[UIImageView alloc] initWithImage:image];
-        [self addSubview:self.zoomImageView];        
+        [self addSubview:self.zoomImageView];
     }
     else
     {
         self.zoomImageView.image = image;
+        self.zoomImageView.bounds = CGRectMake(0, 0, image.size.width, image.size.height);
     }
-    
+
     [self configureForImageSize:image.size];
+
 }
 
 - (void)configureForImageSize:(CGSize)imageSize
@@ -145,6 +147,12 @@
 
 - (void)setMaxMinZoomScalesForCurrentBounds
 {
+    if (_imageSize.width == 0 || _imageSize.height == 0) {
+        self.minimumZoomScale = 0;
+        self.maximumZoomScale = 0;
+        return;
+    }
+
     CGSize boundsSize = self.bounds.size;
     CGFloat maxScale = 1;
     
@@ -170,10 +178,7 @@
     self.minimumZoomScale = minScale;
 }
 
-#pragma mark -
-#pragma mark Methods called during rotation to preserve the zoomScale and the visible portion of the image
-
-#pragma mark - Rotation support
+#pragma mark - Methods called during rotation to preserve the zoomScale and the visible portion of the image
 
 - (void)prepareToResize
 {

--- a/ASMediaFocusManager/ASMediaFocusController.h
+++ b/ASMediaFocusManager/ASMediaFocusController.h
@@ -8,6 +8,13 @@
 
 #import <UIKit/UIKit.h>
 #import "ASImageScrollView.h"
+#import "ASMediaInfo.h"
+
+@class ASMediaFocusController;
+
+@protocol ASMediaFocusControllerDelegate <NSObject>
+- (void)focusController:(ASMediaFocusController *)controller accessoryViewShown:(BOOL)visible;
+@end
 
 @interface ASMediaFocusController : UIViewController
 
@@ -21,11 +28,16 @@
 @property (strong, nonatomic) UIView *playerView;
 @property (strong, nonatomic) UIView *controlView;
 @property (assign, nonatomic) CGFloat controlMargin;
+@property (strong, nonatomic) ASMediaInfo *info;
+@property (weak, nonatomic) id<ASMediaFocusControllerDelegate> delegate;
 
-- (void)updateOrientationAnimated:(BOOL)animated;
 - (void)showPlayerWithURL:(NSURL *)url;
-
+- (void)setInfo:(ASMediaInfo *)info withCachedImage:(UIImage *)cachedImage;
 - (void)focusDidEndWithZoomEnabled:(BOOL)zoomEnabled;
 - (void)defocusWillStart;
+- (BOOL)accessoryViewCanShow;
+
+- (void)pauseVideo;
+- (void)playVideo;
 
 @end

--- a/ASMediaFocusManager/ASMediaFocusController.h
+++ b/ASMediaFocusManager/ASMediaFocusController.h
@@ -9,11 +9,14 @@
 #import <UIKit/UIKit.h>
 #import "ASImageScrollView.h"
 #import "ASMediaInfo.h"
+#import "ASMediaFocusManager.h"
 
 @class ASMediaFocusController;
 
 @protocol ASMediaFocusControllerDelegate <NSObject>
 - (void)focusController:(ASMediaFocusController *)controller accessoryViewShown:(BOOL)visible;
+- (BOOL)focusController:(ASMediaFocusController *)controller shouldLoadMediaDirectly:(ASMediaInfo *)info;
+- (void)focusController:(ASMediaFocusController *)controller loadMedia:(ASMediaInfo *)info completion:(ASMediaLoadCompletion)completion;
 @end
 
 @interface ASMediaFocusController : UIViewController

--- a/ASMediaFocusManager/ASMediaFocusController.m
+++ b/ASMediaFocusManager/ASMediaFocusController.m
@@ -135,11 +135,27 @@ static char const kPlayerPresentationSizeContext;
                 }];
             }
         }
+
+        if (info.accessoryView.superview != self.accessoryView) {
+            self.titleLabel.hidden = YES;
+
+            [self.accessoryView addSubview:info.accessoryView];
+
+            [info.accessoryView sizeToFit];
+            CGFloat accessoryHeight = info.accessoryView.frame.size.height;
+            info.accessoryView.frame = CGRectMake(0,
+                                                  CGRectGetMaxY(self.accessoryView.bounds) - accessoryHeight,
+                                                  self.accessoryView.frame.size.width,
+                                                  accessoryHeight);
+
+            info.accessoryView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
+        }
     }
 }
 
 - (void)showPlayerWithURL:(NSURL *)url
 {
+    [self.playerView removeFromSuperview];
     self.playerView = [[PlayerView alloc] initWithFrame:self.mainImageView.bounds];
     [self.mainImageView addSubview:self.playerView];
     self.playerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;

--- a/ASMediaFocusManager/ASMediaFocusController.m
+++ b/ASMediaFocusManager/ASMediaFocusController.m
@@ -44,9 +44,9 @@ static char const kPlayerPresentationSizeContext;
 
 @implementation ASMediaFocusController
 
-- (id)init
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
-    if ((self = [super init])) {
+    if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) {
         self.doubleTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
         self.doubleTapGesture.numberOfTapsRequired = 2;
         self.controlMargin = kDefaultControlMargin;

--- a/ASMediaFocusManager/ASMediaFocusController.m
+++ b/ASMediaFocusManager/ASMediaFocusController.m
@@ -8,11 +8,14 @@
 
 #import "ASMediaFocusController.h"
 #import "ASVideoControlView.h"
+#import "NSURL+ASMediaFocusManager.h"
+#import "UIImage+ASMediaFocusManager.h"
 #import <QuartzCore/QuartzCore.h>
 #import <AVFoundation/AVFoundation.h>
 
-static NSTimeInterval const kDefaultOrientationAnimationDuration = 0.4;
+
 static CGFloat const kDefaultControlMargin = 5;
+static char const kPlayerPresentationSizeContext;
 
 @interface PlayerView : UIView
 
@@ -41,9 +44,9 @@ static CGFloat const kDefaultControlMargin = 5;
 
 @implementation ASMediaFocusController
 
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+- (id)init
 {
-    if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) {
+    if ((self = [super init])) {
         self.doubleTapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
         self.doubleTapGesture.numberOfTapsRequired = 2;
         self.controlMargin = kDefaultControlMargin;
@@ -73,53 +76,6 @@ static CGFloat const kDefaultControlMargin = 5;
     self.accessoryView.alpha = 0;
 }
 
-- (void)viewDidUnload
-{
-    [self setMainImageView:nil];
-    [self setContentView:nil];
-    [super viewDidUnload];
-}
-
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChangeNotification:) name:UIDeviceOrientationDidChangeNotification object:nil];
-    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-}
-
-- (void)viewWillDisappear:(BOOL)animated
-{
-    [super viewWillDisappear:animated];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
-    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-}
-
-- (NSUInteger)supportedInterfaceOrientations
-{
-    return UIInterfaceOrientationMaskPortrait;
-}
-
-- (BOOL)isParentSupportingInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
-{
-    switch(toInterfaceOrientation)
-    {
-        case UIInterfaceOrientationPortrait:
-            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskPortrait;
-            
-        case UIInterfaceOrientationPortraitUpsideDown:
-            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskPortraitUpsideDown;
-            
-        case UIInterfaceOrientationLandscapeLeft:
-            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskLandscapeLeft;
-            
-        case UIInterfaceOrientationLandscapeRight:
-            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskLandscapeRight;
-            
-        case UIInterfaceOrientationUnknown:
-            return YES;
-    }
-}
-
 - (void)beginAppearanceTransition:(BOOL)isAppearing animated:(BOOL)animated
 {
     if(!isAppearing)
@@ -139,84 +95,39 @@ static CGFloat const kDefaultControlMargin = 5;
     }
 }
 
-#pragma mark - Public
-- (void)updateOrientationAnimated:(BOOL)animated
+- (void)viewDidAppear:(BOOL)animated
 {
-    CGAffineTransform transform;
-    CGRect frame;
-    NSTimeInterval duration = kDefaultOrientationAnimationDuration;
-    
-    if([UIDevice currentDevice].orientation == self.previousOrientation)
-        return;
-    
-    if((UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation) && UIDeviceOrientationIsLandscape(self.previousOrientation))
-       || (UIDeviceOrientationIsPortrait([UIDevice currentDevice].orientation) && UIDeviceOrientationIsPortrait(self.previousOrientation)))
-    {
-        duration *= 2;
-    }
-    
-    if(([UIDevice currentDevice].orientation == UIDeviceOrientationPortrait)
-       || [self isParentSupportingInterfaceOrientation:(UIInterfaceOrientation)[UIDevice currentDevice].orientation])
-    {
-        transform = CGAffineTransformIdentity;
-    }
-    else
-    {
-        switch ([UIDevice currentDevice].orientation)
+    [super viewDidAppear:animated];
+    [self.player play];
+}
+
+#pragma mark - Public
+
+- (void)setInfo:(ASMediaInfo *)info withCachedImage:(UIImage *)cachedImage
+{
+    if (_info != info) {
+        _info = info;
+
+        self.titleLabel.text = info.title;
+        if (cachedImage) {
+            self.mainImageView.image = cachedImage;
+        } else {
+            self.mainImageView.image = info.initialImage;
+        }
+        self.mainImageView.contentMode = info.contentMode;
+
+        if(info.mediaURL.as_isVideoURL)
         {
-            case UIDeviceOrientationLandscapeRight:
-                if(self.parentViewController.interfaceOrientation == UIInterfaceOrientationPortrait)
-                {
-                    transform = CGAffineTransformMakeRotation(-M_PI_2);
-                }
-                else
-                {
-                    transform = CGAffineTransformMakeRotation(M_PI_2);
-                }
-                break;
-                
-            case UIDeviceOrientationLandscapeLeft:
-                if(self.parentViewController.interfaceOrientation == UIInterfaceOrientationPortrait)
-                {
-                    transform = CGAffineTransformMakeRotation(M_PI_2);
-                }
-                else
-                {
-                    transform = CGAffineTransformMakeRotation(-M_PI_2);
-                }
-                break;
-                
-            case UIDeviceOrientationPortrait:
-                transform = CGAffineTransformIdentity;
-                break;
-                
-            case UIDeviceOrientationPortraitUpsideDown:
-                transform = CGAffineTransformMakeRotation(M_PI);
-                break;
-                
-            case UIDeviceOrientationFaceDown:
-            case UIDeviceOrientationFaceUp:
-            case UIDeviceOrientationUnknown:
-                return;
+            [self showPlayerWithURL:info.mediaURL];
+        }
+        else
+        {
+            __weak __typeof(self) weakSelf = self;
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                [weakSelf loadImageFromURL:info.mediaURL];
+            });
         }
     }
-    
-    if(animated)
-    {
-        frame = self.contentView.frame;
-        [UIView animateWithDuration:duration
-                         animations:^{
-                             self.contentView.transform = transform;
-                             self.contentView.frame = frame;
-                         }];
-    }
-    else
-    {
-        frame = self.contentView.frame;
-        self.contentView.transform = transform;
-        self.contentView.frame = frame;
-    }
-    self.previousOrientation = [UIDevice currentDevice].orientation;
 }
 
 - (void)showPlayerWithURL:(NSURL *)url
@@ -228,7 +139,28 @@ static CGFloat const kDefaultControlMargin = 5;
     self.player = [[AVPlayer alloc] initWithURL:url];
     
     ((PlayerView *)self.playerView).player = self.player;
-    [self.player.currentItem addObserver:self forKeyPath:@"presentationSize" options:NSKeyValueObservingOptionNew context:nil];
+    [self.player.currentItem addObserver:self forKeyPath:@"presentationSize" options:NSKeyValueObservingOptionNew context:(void*)&kPlayerPresentationSizeContext];
+}
+
+- (void)loadImageFromURL:(NSURL *)url
+{
+    NSData *data;
+    NSError *error = nil;
+
+    data = [NSData dataWithContentsOfURL:url options:0 error:&error];
+    if(error != nil)
+    {
+        NSLog(@"Warning: Unable to load image at %@. %@", url, error);
+    }
+    else
+    {
+        UIImage *image = [[[UIImage alloc] initWithData:data] as_decodedImage];
+        __weak __typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            weakSelf.mainImageView.image = image;
+            [weakSelf.scrollView displayImage:image];
+        });
+    }
 }
 
 - (void)focusDidEndWithZoomEnabled:(BOOL)zoomEnabled
@@ -240,7 +172,7 @@ static CGFloat const kDefaultControlMargin = 5;
     [self.view setNeedsLayout];
     [self showAccessoryView:YES];
     self.playerView.hidden = NO;
-    [self.player play];
+    // player will play when instructed to by the media focus manager.
 }
 
 - (void)defocusWillStart
@@ -248,6 +180,16 @@ static CGFloat const kDefaultControlMargin = 5;
     [self uninstallZoomView];
     [self pinAccessoryView];
     [self.player pause];
+}
+
+- (void)pauseVideo
+{
+    [self.player pause];
+}
+
+- (void)playVideo
+{
+    [self.player play];
 }
 
 #pragma mark - Private
@@ -312,6 +254,8 @@ static CGFloat const kDefaultControlMargin = 5;
                          self.accessoryView.alpha = (visible?1:0);
                      }
                      completion:nil];
+
+    [self.delegate focusController:self accessoryViewShown:visible];
 }
 
 - (BOOL)accessoryViewsVisible
@@ -368,7 +312,7 @@ static CGFloat const kDefaultControlMargin = 5;
 #pragma mark - Actions
 - (void)handleTap:(UITapGestureRecognizer*)gesture
 {
-    if(self.scrollView.zoomScale == self.scrollView.minimumZoomScale)
+    if ([self accessoryViewCanShow])
     {
         [self showAccessoryView:![self accessoryViewsVisible]];
     }
@@ -408,7 +352,14 @@ static CGFloat const kDefaultControlMargin = 5;
     
 }
 
+- (BOOL)accessoryViewCanShow
+{
+    return (self.scrollView.zoomScale == self.scrollView.minimumZoomScale);
+}
+
+
 #pragma mark - UIScrollViewDelegate
+
 - (UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView
 {
     return self.scrollView.zoomImageView;
@@ -416,18 +367,17 @@ static CGFloat const kDefaultControlMargin = 5;
 
 - (void)scrollViewDidZoom:(UIScrollView *)scrollView
 {
-    [self showAccessoryView:(self.scrollView.zoomScale == self.scrollView.minimumZoomScale)];
-}
-
-#pragma mark - Notifications
-- (void)orientationDidChangeNotification:(NSNotification *)notification
-{
-    [self updateOrientationAnimated:YES];
+    [self showAccessoryView:[self accessoryViewCanShow]];
 }
 
 #pragma mark - KVO
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    [self.view setNeedsLayout];
+    if (context == &kPlayerPresentationSizeContext) {
+        [self.view setNeedsLayout];
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
 }
 @end

--- a/ASMediaFocusManager/ASMediaFocusController.xib
+++ b/ASMediaFocusManager/ASMediaFocusController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1514" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ASMediaFocusController">

--- a/ASMediaFocusManager/ASMediaFocusController.xib
+++ b/ASMediaFocusManager/ASMediaFocusController.xib
@@ -4,7 +4,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ASMediaFocusController">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner">
             <connections>
                 <outlet property="accessoryView" destination="0cG-lC-hKN" id="mlu-tg-iLW"/>
                 <outlet property="contentView" destination="12" id="13"/>
@@ -14,7 +14,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="1">
+        <view contentMode="scaleToFill" id="1" customClass="ASMediaFocusController">
             <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -71,6 +71,8 @@ typedef void(^ASMediaLoadCompletion)(id media, NSError *error);
 // Image used to show a play icon on video thumbnails. Defaults to nil (uses internal image).
 @property (nonatomic, strong) UIImage *playImage;
 
+@property (nonatomic, assign, readonly) NSUInteger currentlyVisibleMediaIndex;
+
 // Install focusing gesture on the specified array of views.
 - (void)installOnViews:(NSArray *)views;
 // Install focusing gesture on the specified view.

--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ASMediaInfo.h"
 
 @class ASMediaFocusManager;
 
@@ -14,14 +15,15 @@
 
 // Returns the view controller in which the focus controller is going to be added. This can be any view controller, full screen or not.
 - (UIViewController *)parentViewControllerForMediaFocusManager:(ASMediaFocusManager *)mediaFocusManager;
-// Returns the URL where the media (image or video) is stored. The URL may be local (file://) or distant (http://).
-- (NSURL *)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager mediaURLForView:(UIView *)view;
-// Returns the title for this media view. Return nil if you don't want any title to appear.
-- (NSString *)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager titleForView:(UIView *)view;
+
+// Returns the media info (url & title) for the given view. This is used over mediaURLForView: if it is implemented.
+- (ASMediaInfo *)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager mediaInfoForView:(UIView *)view;
 
 @optional
-// Returns an image view that represents the media view. This image from this view is used in the focusing animation view. It is usually a small image. If not implemented, default is the initial media view in case it's an UIImageview.
-- (UIImageView *)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager imageViewForView:(UIView *)view;
+
+// Returns a list of media info objects that can be displayed in a horizontally-paged carousel. If the object returned by mediaInfoForView is in the returned list, it will be the first thing shown, and the user can swipe left or right from it depending on its location in the list. If the object returned by that is not in the returned list, it will be prepended to the beginning, and all items in this list will be accessible by swiping to the right.
+- (NSArray *)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager mediaInfoListForView:(UIView *)view;
+
 // Returns the final focused frame for this media view. This frame is usually a full screen frame. If not implemented, default is the parent view controller's view frame.
 - (CGRect)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager finalFrameForView:(UIView *)view;
 
@@ -33,6 +35,8 @@
 - (void)mediaFocusManagerWillDisappear:(ASMediaFocusManager *)mediaFocusManager;
 // Called when the view has be dismissed by the 'done' button or by gesture.
 - (void)mediaFocusManagerDidDisappear:(ASMediaFocusManager *)mediaFocusManager;
+// called after a swipe shows a new media info item.
+- (void)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager didSwipeToMediaInfo:(ASMediaInfo *)info;
 // Called before mediaURLForView to check if image is already on memory.
 - (UIImage*)mediaFocusManager:(ASMediaFocusManager*)mediaFocusManager cachedImageForView:(UIView*)view;
 

--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "ASMediaInfo.h"
 
+typedef void(^ASMediaLoadCompletion)(id media, NSError *error);
+
 @class ASMediaFocusManager;
 
 @protocol ASMediasFocusDelegate <NSObject>
@@ -39,6 +41,8 @@
 - (void)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager didSwipeToMediaInfo:(ASMediaInfo *)info;
 // Called before mediaURLForView to check if image is already on memory.
 - (UIImage*)mediaFocusManager:(ASMediaFocusManager*)mediaFocusManager cachedImageForView:(UIView*)view;
+
+- (void)mediaFocusManager:(ASMediaFocusManager *)mediaFocusManager loadMediaForInfo:(ASMediaInfo *)info completion:(ASMediaLoadCompletion)completion;
 
 @end
 

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -186,6 +186,12 @@ static CGFloat const kSwipeOffset = 100;
     return viewController;
 }
 
+- (NSUInteger)currentlyVisibleMediaIndex
+{
+    ASMediaInfo *currentInfo = self.focusViewController.info;
+    return [self.mediaInfoItems indexOfObject:currentInfo];
+}
+
 #pragma mark - Focus/Defocus
 - (void)startFocusingView:(UIView *)mediaView
 {

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -174,7 +174,7 @@ static CGFloat const kSwipeOffset = 100;
         cachedImage = [self.delegate mediaFocusManager:self cachedImageForView:mediaView];
     }
 
-    ASMediaFocusController *viewController = [[ASMediaFocusController alloc] init];
+    ASMediaFocusController *viewController = [[ASMediaFocusController alloc] initWithNibName:nil bundle:nil];
     viewController.delegate = self;
     [viewController setInfo:mediaInfo withCachedImage:cachedImage];
 

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -174,7 +174,7 @@ static CGFloat const kSwipeOffset = 100;
         cachedImage = [self.delegate mediaFocusManager:self cachedImageForView:mediaView];
     }
 
-    ASMediaFocusController *viewController = [[ASMediaFocusController alloc] initWithNibName:nil bundle:nil];
+    ASMediaFocusController *viewController = [[ASMediaFocusController alloc] initWithNibName:@"ASMediaFocusController" bundle:[NSBundle bundleForClass:[self class]]];
     viewController.delegate = self;
     [viewController setInfo:mediaInfo withCachedImage:cachedImage];
 

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -551,6 +551,20 @@ static CGFloat const kSwipeOffset = 100;
                      completion:nil];
 }
 
+- (BOOL)focusController:(ASMediaFocusController *)controller shouldLoadMediaDirectly:(ASMediaInfo *)info
+{
+    if ([self.delegate respondsToSelector:@selector(mediaFocusManager:loadMediaForInfo:completion:)]) {
+        return NO;
+    } else {
+        return YES;
+    }
+}
+
+- (void)focusController:(ASMediaFocusController *)controller loadMedia:(ASMediaInfo *)info completion:(ASMediaLoadCompletion)completion
+{
+    [self.delegate mediaFocusManager:self loadMediaForInfo:info completion:completion];
+}
+
 #pragma mark - UIPageViewControllerDataSource
 
 - (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerBeforeViewController:(UIViewController *)viewController

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -8,7 +8,11 @@
 
 #import "ASMediaFocusManager.h"
 #import "ASMediaFocusController.h"
+#import "ASMediaInfo.h"
 #import "ASVideoBehavior.h"
+#import "ASMediaRotatingViewController.h"
+#import "UIImage+ASMediaFocusManager.h"
+#import "NSURL+ASMediaFocusManager.h"
 #import <QuartzCore/QuartzCore.h>
 
 static CGFloat const kAnimateElasticSizeRatio = 0.03;
@@ -18,12 +22,17 @@ static CGFloat const kAnimateElasticThirdMoveSizeRatio = 0.2;
 static CGFloat const kAnimationDuration = 0.5;
 static CGFloat const kSwipeOffset = 100;
 
-@interface ASMediaFocusManager () <UIGestureRecognizerDelegate>
+@interface ASMediaFocusManager () <UIGestureRecognizerDelegate, UIPageViewControllerDataSource, UIPageViewControllerDelegate, ASMediaFocusControllerDelegate>
 // The media view being focused.
 @property (nonatomic, strong) UIView *mediaView;
-@property (nonatomic, strong) ASMediaFocusController *focusViewController;
+@property (nonatomic, strong, readonly) ASMediaFocusController *focusViewController;
+@property (nonatomic, copy) NSArray *mediaInfoItems;
+
+@property (nonatomic, strong) ASMediaRotatingViewController *rotatingViewController;
+@property (nonatomic, strong) UIPageViewController *mediaPageViewController;
 @property (nonatomic, assign) BOOL isZooming;
 @property (nonatomic, strong) ASVideoBehavior *videoBehavior;
+@property (nonatomic, strong) UIButton *doneButton;
 @end
 
 @implementation ASMediaFocusManager
@@ -49,6 +58,11 @@ static CGFloat const kSwipeOffset = 100;
     return self;
 }
 
+- (ASMediaFocusManager *)focusViewController
+{
+    return self.mediaPageViewController.viewControllers.firstObject;
+}
+
 - (void)installOnViews:(NSArray *)views
 {
     for(UIView *view in views)
@@ -59,19 +73,17 @@ static CGFloat const kSwipeOffset = 100;
 
 - (void)installOnView:(UIView *)view
 {
-    UITapGestureRecognizer *tapGesture;
-    NSURL *url;
-    
-    tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleFocusGesture:)];
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleFocusGesture:)];
     [view addGestureRecognizer:tapGesture];
     view.userInteractionEnabled = YES;
 
     UIPinchGestureRecognizer *pinchRecognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinchFocusGesture:)];
     pinchRecognizer.delegate = self;
     [view addGestureRecognizer:pinchRecognizer];
-    
-    url = [self.delegate mediaFocusManager:self mediaURLForView:view];
-    if(self.addPlayIconOnVideo && [self isVideoURL:url])
+
+    ASMediaInfo *info = [self.delegate mediaFocusManager:self mediaInfoForView:view];
+
+    if(self.addPlayIconOnVideo && info.mediaURL.as_isVideoURL)
     {
         [self.videoBehavior addVideoIconToView:view image:self.playImage];
     }
@@ -90,90 +102,28 @@ static CGFloat const kSwipeOffset = 100;
             [tapGesture requireGestureRecognizerToFail:focusViewController.doubleTapGesture];
             [focusViewController.view addGestureRecognizer:tapGesture];
         }
-        else
-        {
-            [self setupAccessoryViewOnFocusViewController:focusViewController];
-        }
     }
 }
 
-- (void)setupAccessoryViewOnFocusViewController:(ASMediaFocusController *)focusViewController
+- (void)addDoneButton
 {
-    UIButton *doneButton;
-    
-    doneButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    [doneButton setTitle:NSLocalizedString(@"Done", @"Done") forState:UIControlStateNormal];
-    [doneButton addTarget:self action:@selector(handleDefocusGesture:) forControlEvents:UIControlEventTouchUpInside];
-    doneButton.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
-    [doneButton sizeToFit];
-    doneButton.frame = CGRectInset(doneButton.frame, -20, -4);
-    doneButton.layer.borderWidth = 2;
-    doneButton.layer.cornerRadius = 4;
-    doneButton.layer.borderColor = [UIColor whiteColor].CGColor;
-    doneButton.center = CGPointMake(focusViewController.accessoryView.bounds.size.width - doneButton.bounds.size.width/2 - 10, doneButton.bounds.size.height/2 + 20);
-    doneButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;
-    [focusViewController.accessoryView addSubview:doneButton];
+    [self.doneButton removeFromSuperview];
+
+    self.doneButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    [self.doneButton setTitle:NSLocalizedString(@"Done", @"Done") forState:UIControlStateNormal];
+    [self.doneButton addTarget:self action:@selector(handleDefocusGesture:) forControlEvents:UIControlEventTouchUpInside];
+    self.doneButton.backgroundColor = [UIColor colorWithWhite:0 alpha:0.5];
+    [self.doneButton sizeToFit];
+    self.doneButton.frame = CGRectInset(self.doneButton.frame, -20, -4);
+    self.doneButton.layer.borderWidth = 2;
+    self.doneButton.layer.cornerRadius = 4;
+    self.doneButton.layer.borderColor = [UIColor whiteColor].CGColor;
+    self.doneButton.center = CGPointMake(self.mediaPageViewController.view.bounds.size.width - self.doneButton.bounds.size.width/2 - 10, self.doneButton.bounds.size.height/2 + 20);
+    self.doneButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;
+    [self.mediaPageViewController.view addSubview:self.doneButton];
 }
 
 #pragma mark - Utilities
-// Taken from https://github.com/rs/SDWebImage/blob/master/SDWebImage/SDWebImageDecoder.m
-- (UIImage *)decodedImageWithImage:(UIImage *)image
-{
-    if (image.images) {
-        // Do not decode animated images
-        return image;
-    }
-    
-    CGImageRef imageRef = image.CGImage;
-    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    CGRect imageRect = (CGRect){.origin = CGPointZero, .size = imageSize};
-    
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-    
-    int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
-    BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
-                        infoMask == kCGImageAlphaNoneSkipFirst ||
-                        infoMask == kCGImageAlphaNoneSkipLast);
-    
-    // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
-    // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
-    if (infoMask == kCGImageAlphaNone && CGColorSpaceGetNumberOfComponents(colorSpace) > 1) {
-        // Unset the old alpha info.
-        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-        
-        // Set noneSkipFirst.
-        bitmapInfo |= kCGImageAlphaNoneSkipFirst;
-    }
-    // Some PNGs tell us they have alpha but only 3 components. Odd.
-    else if (!anyNonAlpha && CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
-        // Unset the old alpha info.
-        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-        bitmapInfo |= kCGImageAlphaPremultipliedFirst;
-    }
-    
-    // It calculates the bytes-per-row based on the bitsPerComponent and width arguments.
-    CGContextRef context = CGBitmapContextCreate(NULL,
-                                                 imageSize.width,
-                                                 imageSize.height,
-                                                 CGImageGetBitsPerComponent(imageRef),
-                                                 0,
-                                                 colorSpace,
-                                                 bitmapInfo);
-    CGColorSpaceRelease(colorSpace);
-    
-    // If failed, return undecompressed image
-    if (!context) return image;
-    
-    CGContextDrawImage(context, imageRect, imageRef);
-    CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
-    
-    CGContextRelease(context);
-    
-    UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef scale:image.scale orientation:image.imageOrientation];
-    CGImageRelease(decompressedImageRef);
-    return decompressedImage;
-}
 
 - (CGRect)rectInsetsForRect:(CGRect)frame ratio:(CGFloat)ratio
 {
@@ -211,90 +161,29 @@ static CGFloat const kSwipeOffset = 100;
     return fittingSize;
 }
 
-- (ASMediaFocusController *)focusViewControllerForView:(UIView *)mediaView
+- (ASMediaFocusController *)focusViewControllerForView:(UIView *)mediaView mediaInfo:(ASMediaInfo *)mediaInfo
 {
-    ASMediaFocusController *viewController;
-    UIImage *image;
-    UIImageView *imageView = nil;
-    NSURL *url;
-    
-    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManager:imageViewForView:)])
-    {
-        imageView = [self.delegate mediaFocusManager:self imageViewForView:mediaView];
-    }
-    else if([mediaView isKindOfClass:[UIImageView class]])
-    {
-        imageView = (UIImageView *)mediaView;
-    }
-    
-    image = imageView.image;
-    if((imageView == nil) || (image == nil))
-        return nil;
-    
-    url = [self.delegate mediaFocusManager:self mediaURLForView:mediaView];
-    if(url == nil)
+    if(mediaInfo.mediaURL == nil)
     {
         NSLog(@"Warning: url is nil");
         return nil;
     }
 
-    viewController = [[ASMediaFocusController alloc] initWithNibName:nil bundle:nil];
-    [self installDefocusActionOnFocusViewController:viewController];
-    
-    viewController.titleLabel.text = [self.delegate mediaFocusManager:self titleForView:mediaView];
-    viewController.mainImageView.image = image;
-    viewController.mainImageView.contentMode = imageView.contentMode;
-    
+    UIImage *cachedImage = nil;
     if ([self.delegate respondsToSelector:@selector(mediaFocusManager:cachedImageForView:)]) {
-        UIImage *image = [self.delegate mediaFocusManager:self cachedImageForView:mediaView];
-        if (image) {
-            viewController.mainImageView.image = image;
-            return viewController;
-        }
+        cachedImage = [self.delegate mediaFocusManager:self cachedImageForView:mediaView];
     }
-    
-    if([self isVideoURL:url])
+
+    ASMediaFocusController *viewController = [[ASMediaFocusController alloc] init];
+    viewController.delegate = self;
+    [viewController setInfo:mediaInfo withCachedImage:cachedImage];
+
+    if (self.defocusOnVerticalSwipe)
     {
-        [viewController showPlayerWithURL:url];
+        [self installSwipeGestureOnFocusViewController:viewController];
     }
-    else
-    {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            [self loadImageFromURL:url onImageView:viewController.mainImageView];
-        });
-    }
-    
+
     return viewController;
-}
-
-- (void)loadImageFromURL:(NSURL *)url onImageView:(UIImageView *)imageView
-{
-    NSData *data;
-    NSError *error = nil;
-    
-    data = [NSData dataWithContentsOfURL:url options:0 error:&error];
-    if(error != nil)
-    {
-        NSLog(@"Warning: Unable to load image at %@. %@", url, error);
-    }
-    else
-    {
-        UIImage *image;
-        
-        image = [[UIImage alloc] initWithData:data];
-        image = [self decodedImageWithImage:image];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            imageView.image = image;
-        });
-    }
-}
-
-- (BOOL)isVideoURL:(NSURL *)url
-{
-    NSString *extension;
-    
-    extension = url.pathExtension.lowercaseString;
-    return ([extension isEqualToString:@"mp4"] || [extension isEqualToString:@"mov"]);
 }
 
 #pragma mark - Focus/Defocus
@@ -307,17 +196,38 @@ static CGFloat const kSwipeOffset = 100;
     NSTimeInterval duration;
     CGRect finalImageFrame;
     __block CGRect untransformedFinalImageFrame;
-    
-    focusViewController = [self focusViewControllerForView:mediaView];
+
+    self.mediaPageViewController = [[UIPageViewController alloc] initWithTransitionStyle:UIPageViewControllerTransitionStyleScroll navigationOrientation:UIPageViewControllerNavigationOrientationHorizontal options:@{UIPageViewControllerOptionInterPageSpacingKey: @10}];
+    self.mediaPageViewController.dataSource = self;
+    self.mediaPageViewController.delegate = self;
+
+    if (!self.isDefocusingWithTap) {
+        [self addDoneButton];
+    }
+
+    self.rotatingViewController = [[ASMediaRotatingViewController alloc] initWithViewController:self.mediaPageViewController];
+
+    ASMediaInfo *mediaInfo = [self.delegate mediaFocusManager:self mediaInfoForView:mediaView];
+
+    focusViewController = [self focusViewControllerForView:mediaView mediaInfo:mediaInfo];
     if(focusViewController == nil)
         return;
-    
-    self.focusViewController = focusViewController;
-    if(self.defocusOnVerticalSwipe)
-    {
-        [self installSwipeGestureOnFocusView];
+
+    [self.mediaPageViewController setViewControllers:@[focusViewController] direction:UIPageViewControllerNavigationDirectionForward animated:NO completion:nil];
+
+    if ([self.delegate respondsToSelector:@selector(mediaFocusManager:mediaInfoListForView:)]) {
+        NSArray *mediaInfoItems = [self.delegate mediaFocusManager:self mediaInfoListForView:mediaView];
+        if ([mediaInfoItems indexOfObject:mediaInfo] == NSNotFound) {
+            NSMutableArray *mutableItems = [mediaInfoItems mutableCopy];
+            [mutableItems insertObject:mediaInfo atIndex:0];
+            self.mediaInfoItems = mutableItems;
+        } else {
+            self.mediaInfoItems = mediaInfoItems;
+        }
+    } else {
+        self.mediaInfoItems = @[mediaInfo];
     }
-    
+
     // This should be called after swipe gesture is installed to make sure the nav bar doesn't hide before animation begins.
     if(self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManagerWillAppear:)])
     {
@@ -326,10 +236,10 @@ static CGFloat const kSwipeOffset = 100;
     
     self.mediaView = mediaView;
     parentViewController = [self.delegate parentViewControllerForMediaFocusManager:self];
-    [parentViewController addChildViewController:focusViewController];
-    [parentViewController.view addSubview:focusViewController.view];
+    [parentViewController addChildViewController:self.rotatingViewController];
+    [parentViewController.view addSubview:self.rotatingViewController.view];
     
-    focusViewController.view.frame = parentViewController.view.bounds;
+    self.rotatingViewController.view.frame = parentViewController.view.bounds;
     mediaView.hidden = YES;
     
     imageView = focusViewController.mainImageView;
@@ -355,13 +265,13 @@ static CGFloat const kSwipeOffset = 100;
         
         size = [self sizeThatFitsInSize:finalImageFrame.size initialSize:imageView.image.size];
         finalImageFrame.size = size;
-        finalImageFrame.origin.x = (focusViewController.view.bounds.size.width - size.width)/2;
-        finalImageFrame.origin.y = (focusViewController.view.bounds.size.height - size.height)/2;
+        finalImageFrame.origin.x = (self.rotatingViewController.view.bounds.size.width - size.width)/2;
+        finalImageFrame.origin.y = (self.rotatingViewController.view.bounds.size.height - size.height)/2;
     }
     
     [UIView animateWithDuration:self.animationDuration
                      animations:^{
-                         focusViewController.view.backgroundColor = self.backgroundColor;
+                         self.rotatingViewController.view.backgroundColor = self.backgroundColor;
                          [focusViewController beginAppearanceTransition:YES animated:YES];
                      }];
     
@@ -384,7 +294,7 @@ static CGFloat const kSwipeOffset = 100;
                          imageView.transform = CGAffineTransformIdentity;
                          initialFrame = imageView.frame;
                          imageView.frame = frame;
-                         [focusViewController updateOrientationAnimated:NO];
+                         [self.rotatingViewController updateOrientationAnimated:NO];
                          // This is the final image frame. No transform.
                          untransformedFinalImageFrame = imageView.frame;
                          frame = (self.elasticAnimation?[self rectInsetsForRect:untransformedFinalImageFrame ratio:-kAnimateElasticSizeRatio]:untransformedFinalImageFrame);
@@ -419,7 +329,8 @@ static CGFloat const kSwipeOffset = 100;
                                                                                         imageView.frame = untransformedFinalImageFrame;
                                                                                     }
                                                                                     completion:^(BOOL finished) {
-                                                                                        [self.focusViewController focusDidEndWithZoomEnabled:self.zoomEnabled];
+                                                                                        [focusViewController focusDidEndWithZoomEnabled:self.zoomEnabled];
+                                                                                        [focusViewController playVideo];
                                                                                         self.isZooming = NO;
                                                                                         
                                                                                         if (self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManagerDidAppear:)])
@@ -448,16 +359,16 @@ static CGFloat const kSwipeOffset = 100;
     view.frame = finalFrame;
 }
 
-- (void)updateBoundsDuringAnimationWithElasticRatio:(CGFloat)ratio
+- (void)updateBoundsDuringAnimationWithElasticRatio:(CGFloat)ratio forFocusController:(ASMediaFocusController *)focusViewController
 {
     CGRect frame;
     CGRect initialFrame;
     
-    initialFrame = self.focusViewController.playerView.frame;
+    initialFrame = focusViewController.playerView.frame;
     frame = self.mediaView.bounds;
     frame = (self.elasticAnimation?[self rectInsetsForRect:frame ratio:ratio]:frame);
-    self.focusViewController.mainImageView.bounds = frame;
-    [self updateAnimatedView:self.focusViewController.playerView fromFrame:initialFrame toFrame:frame];
+    focusViewController.mainImageView.bounds = frame;
+    [self updateAnimatedView:focusViewController.playerView fromFrame:initialFrame toFrame:frame];
 }
 
 - (void)endFocusing
@@ -476,7 +387,7 @@ static CGFloat const kSwipeOffset = 100;
     
     [UIView animateWithDuration:self.animationDuration
                      animations:^{
-                         self.focusViewController.view.backgroundColor = [UIColor clearColor];
+                         self.rotatingViewController.view.backgroundColor = [UIColor clearColor];
                      }];
     
     [UIView animateWithDuration:self.animationDuration/2
@@ -489,48 +400,52 @@ static CGFloat const kSwipeOffset = 100;
                           delay:0
                         options:0
                      animations:^{
-                         CGRect frame;
-                         
+
                          if (self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManagerWillDisappear:)])
                          {
                              [self.delegate mediaFocusManagerWillDisappear:self];
                          }
-                         
-                         frame = self.focusViewController.playerView.frame;
-                         self.focusViewController.contentView.transform = CGAffineTransformIdentity;
+
+                         self.mediaPageViewController.view.transform = CGAffineTransformIdentity;
                          contentView.center = [contentView.superview convertPoint:self.mediaView.center fromView:self.mediaView.superview];
                          contentView.transform = self.mediaView.transform;
-                         [self updateBoundsDuringAnimationWithElasticRatio:kAnimateElasticSizeRatio];
+                         [self updateBoundsDuringAnimationWithElasticRatio:kAnimateElasticSizeRatio forFocusController:self.focusViewController];
                      }
                      completion:^(BOOL finished) {
                          [UIView animateWithDuration:(self.elasticAnimation?self.animationDuration*kAnimateElasticDurationRatio/3:0)
                                           animations:^{
-                                              [self updateBoundsDuringAnimationWithElasticRatio:-kAnimateElasticSizeRatio*kAnimateElasticSecondMoveSizeRatio];
+                                              [self updateBoundsDuringAnimationWithElasticRatio:-kAnimateElasticSizeRatio*kAnimateElasticSecondMoveSizeRatio forFocusController:self.focusViewController];
                                           }
                                           completion:^(BOOL finished) {
                                               [UIView animateWithDuration:(self.elasticAnimation?self.animationDuration*kAnimateElasticDurationRatio/3:0)
                                                                animations:^{
-                                                                   [self updateBoundsDuringAnimationWithElasticRatio:kAnimateElasticSizeRatio*kAnimateElasticThirdMoveSizeRatio];
+                                                                   [self updateBoundsDuringAnimationWithElasticRatio:kAnimateElasticSizeRatio*kAnimateElasticThirdMoveSizeRatio forFocusController:self.focusViewController];
                                                                }
                                                                completion:^(BOOL finished) {
                                                                    [UIView animateWithDuration:(self.elasticAnimation?self.animationDuration*kAnimateElasticDurationRatio/3:0)
                                                                                     animations:^{
-                                                                                        [self updateBoundsDuringAnimationWithElasticRatio:0];
+                                                                                        [self updateBoundsDuringAnimationWithElasticRatio:0 forFocusController:self.focusViewController];
                                                                                     }
                                                                                     completion:^(BOOL finished) {
-                                                                                        self.mediaView.hidden = NO;
-                                                                                        [self.focusViewController.view removeFromSuperview];
-                                                                                        [self.focusViewController removeFromParentViewController];
-                                                                                        self.focusViewController = nil;
-                                                                                        
-                                                                                        if (self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManagerDidDisappear:)])
-                                                                                        {
-                                                                                            [self.delegate mediaFocusManagerDidDisappear:self];
-                                                                                        }
+                                                                                        [self endFocusingFinished];
                                                                                     }];
                                                                }];
                                           }];
                      }];
+}
+
+- (void)endFocusingFinished
+{
+    self.mediaView.hidden = NO;
+    [self.rotatingViewController.view removeFromSuperview];
+    [self.rotatingViewController removeFromParentViewController];
+    self.rotatingViewController = nil;
+    self.mediaPageViewController = nil;
+
+    if (self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManagerDidDisappear:)])
+    {
+        [self.delegate mediaFocusManagerDidDisappear:self];
+    }
 }
 
 #pragma mark - Gestures
@@ -561,18 +476,18 @@ static CGFloat const kSwipeOffset = 100;
 }
 
 #pragma mark - Dismiss on swipe
-- (void)installSwipeGestureOnFocusView
+
+- (void)installSwipeGestureOnFocusViewController:(ASMediaFocusController *)focusViewController
 {
-    UISwipeGestureRecognizer *swipeGesture;
-    
-    swipeGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleDefocusBySwipeGesture:)];
+    UISwipeGestureRecognizer *swipeGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleDefocusBySwipeGesture:)];
     swipeGesture.direction = UISwipeGestureRecognizerDirectionUp;
-    [self.focusViewController.view addGestureRecognizer:swipeGesture];
-    
+    [focusViewController.view addGestureRecognizer:swipeGesture];
+
     swipeGesture = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleDefocusBySwipeGesture:)];
     swipeGesture.direction = UISwipeGestureRecognizerDirectionDown;
-    [self.focusViewController.view addGestureRecognizer:swipeGesture];
-    self.focusViewController.view.userInteractionEnabled = YES;
+    [focusViewController.view addGestureRecognizer:swipeGesture];
+
+    focusViewController.view.userInteractionEnabled = YES;
 }
 
 - (void)handleDefocusBySwipeGesture:(UISwipeGestureRecognizer *)gesture
@@ -587,7 +502,7 @@ static CGFloat const kSwipeOffset = 100;
     
     [UIView animateWithDuration:duration
                      animations:^{
-                         self.focusViewController.view.backgroundColor = [UIColor clearColor];
+                         self.rotatingViewController.view.backgroundColor = [UIColor clearColor];
                      }];
     
     [UIView animateWithDuration:duration/2
@@ -601,7 +516,7 @@ static CGFloat const kSwipeOffset = 100;
                          {
                              [self.delegate mediaFocusManagerWillDisappear:self];
                          }
-                         self.focusViewController.contentView.transform = CGAffineTransformIdentity;
+                         self.mediaPageViewController.view.transform = CGAffineTransformIdentity;
                          
                          contentView.center = CGPointMake(self.focusViewController.view.center.x, self.focusViewController.view.center.y + offset);
                      }
@@ -610,20 +525,89 @@ static CGFloat const kSwipeOffset = 100;
                                           animations:^{
                                               contentView.center = [contentView.superview convertPoint:self.mediaView.center fromView:self.mediaView.superview];
                                               contentView.transform = self.mediaView.transform;
-                                              [self updateBoundsDuringAnimationWithElasticRatio:0];
+                                              [self updateBoundsDuringAnimationWithElasticRatio:0 forFocusController:self.focusViewController];
                                            }
                                           completion:^(BOOL finished) {
-                                              self.mediaView.hidden = NO;
-                                              [self.focusViewController.view removeFromSuperview];
-                                              [self.focusViewController removeFromParentViewController];
-                                              self.focusViewController = nil;
-                                              
-                                              if (self.delegate && [self.delegate respondsToSelector:@selector(mediaFocusManagerDidDisappear:)])
-                                              {
-                                                  [self.delegate mediaFocusManagerDidDisappear:self];
-                                              }
+                                              [self endFocusingFinished];
                                           }];
                      }];
+}
+
+#pragma mark - ASMediaFocusControllerDelegate
+
+- (void)focusController:(ASMediaFocusController *)controller accessoryViewShown:(BOOL)visible
+{
+    CGFloat newAlpha = (visible ? 1 : 0);
+    if (self.doneButton.alpha == newAlpha) {
+        return;
+    }
+
+    [UIView animateWithDuration:0.5
+                          delay:0
+                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionAllowUserInteraction
+                     animations:^{
+                         self.doneButton.alpha = newAlpha;
+                     }
+                     completion:nil];
+}
+
+#pragma mark - UIPageViewControllerDataSource
+
+- (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerBeforeViewController:(UIViewController *)viewController
+{
+    ASMediaInfo *currentInfo = self.focusViewController.info;
+    NSUInteger index = [self.mediaInfoItems indexOfObject:currentInfo];
+
+    if (index == 0) {
+        return nil;
+    }
+
+    ASMediaInfo *newInfo = self.mediaInfoItems[index - 1];
+
+    ASMediaFocusController *controller = [self focusViewControllerForView:self.mediaView mediaInfo:newInfo];
+    [controller focusDidEndWithZoomEnabled:self.zoomEnabled]; // sets up view for zooming
+    return controller;
+}
+
+- (UIViewController *)pageViewController:(UIPageViewController *)pageViewController viewControllerAfterViewController:(UIViewController *)viewController
+{
+    ASMediaInfo *currentInfo = self.focusViewController.info;
+    NSUInteger index = [self.mediaInfoItems indexOfObject:currentInfo];
+
+    if (index >= self.mediaInfoItems.count - 1) {
+        return nil;
+    }
+
+    ASMediaInfo *newInfo = self.mediaInfoItems[index + 1];
+
+    ASMediaFocusController *controller = [self focusViewControllerForView:self.mediaView mediaInfo:newInfo];
+    [controller focusDidEndWithZoomEnabled:self.zoomEnabled]; // sets up view for zooming
+    return controller;
+}
+
+#pragma mark - UIPageViewControllerDelegate
+
+- (void)pageViewController:(UIPageViewController *)pageViewController willTransitionToViewControllers:(NSArray *)pendingViewControllers
+{
+    [self.focusViewController pauseVideo]; // pauses the current focus controller before transitioning
+}
+
+- (void)pageViewController:(UIPageViewController *)pageViewController didFinishAnimating:(BOOL)finished previousViewControllers:(NSArray *)previousViewControllers transitionCompleted:(BOOL)completed
+{
+    if (completed) {
+        // This will hide/show the done button depending on the zoom level of the newly shown view controller.
+        [self focusController:self.focusViewController accessoryViewShown:[self.focusViewController accessoryViewCanShow]];
+        
+        if ([self.delegate respondsToSelector:@selector(mediaFocusManager:didSwipeToMediaInfo:)]) {
+            [self.delegate mediaFocusManager:self didSwipeToMediaInfo:self.focusViewController.info];
+        }
+    }
+    [self.focusViewController playVideo]; // plays the current focus controller after transitioning (may be the one we were transitioning from if completed is false).
+}
+
+- (NSUInteger)pageViewControllerSupportedInterfaceOrientations:(UIPageViewController *)pageViewController
+{
+    return UIInterfaceOrientationMaskAll;
 }
 
 @end

--- a/ASMediaFocusManager/ASMediaInfo.h
+++ b/ASMediaFocusManager/ASMediaInfo.h
@@ -21,5 +21,7 @@
 @property (nonatomic, strong, readonly) UIImage *initialImage;
 /** The content mode to use for the image view in the focus controller. Defaults to UIViewContentModeScaleAspectFit. */
 @property (nonatomic, assign) UIViewContentMode contentMode;
+/** Optional property to show a view pinned to the bottom of the focused area of the media. If present, this view is shown in place of the title. */
+@property (nonatomic, strong) UIView *accessoryView;
 
 @end

--- a/ASMediaFocusManager/ASMediaInfo.h
+++ b/ASMediaFocusManager/ASMediaInfo.h
@@ -1,0 +1,25 @@
+//
+//  ASMediaInfo.h
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/5/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ASMediaInfo : NSObject
+
+- (instancetype)initWithURL:(NSURL *)mediaURL initialImage:(UIImage *)image;
+- (instancetype)initWithURL:(NSURL *)mediaURL initialImage:(UIImage *)image title:(NSString *)title;
+
+/** the URL where the media (image or video) is stored. The URL may be local (file://) or distant (http://). */
+@property (nonatomic, copy, readonly) NSURL *mediaURL;
+/** the title for this media view. Set to nil if you don't want any title to appear. */
+@property (nonatomic, copy, readonly) NSString *title;
+/** The initial image to display in the focus controller before the media URL's image/video is loaded. */
+@property (nonatomic, strong, readonly) UIImage *initialImage;
+/** The content mode to use for the image view in the focus controller. Defaults to UIViewContentModeScaleAspectFit. */
+@property (nonatomic, assign) UIViewContentMode contentMode;
+
+@end

--- a/ASMediaFocusManager/ASMediaInfo.m
+++ b/ASMediaFocusManager/ASMediaInfo.m
@@ -1,0 +1,45 @@
+//
+//  ASMediaInfo.m
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/5/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import "ASMediaInfo.h"
+
+@implementation ASMediaInfo
+
+- (instancetype)initWithURL:(NSURL *)mediaURL initialImage:(UIImage *)image
+{
+    return [self initWithURL:mediaURL initialImage:image title:nil];
+}
+
+- (instancetype)initWithURL:(NSURL *)mediaURL initialImage:(UIImage *)image title:(NSString *)title
+{
+    self = [super init];
+    if (self) {
+        _mediaURL = [mediaURL copy];
+        _title = [title copy];
+        _initialImage = image;
+        _contentMode = UIViewContentModeScaleAspectFit;
+    }
+    return self;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (![object isKindOfClass:[self class]]) {
+        return NO;
+    }
+    ASMediaInfo *info = object;
+
+    return (info.mediaURL == self.mediaURL || [info.mediaURL isEqual:self.mediaURL]);
+}
+
+- (NSUInteger)hash
+{
+    return self.mediaURL.hash ^ self.title.hash ^ self.initialImage.hash;
+}
+
+@end

--- a/ASMediaFocusManager/ASMediaRotatingViewController.h
+++ b/ASMediaFocusManager/ASMediaRotatingViewController.h
@@ -1,0 +1,17 @@
+//
+//  ASRotatingMediaPageViewController.h
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/8/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ASMediaRotatingViewController : UIViewController
+
+- (instancetype)initWithViewController:(UIViewController *)viewController;
+
+- (void)updateOrientationAnimated:(BOOL)animated;
+
+@end

--- a/ASMediaFocusManager/ASMediaRotatingViewController.m
+++ b/ASMediaFocusManager/ASMediaRotatingViewController.m
@@ -1,0 +1,156 @@
+//
+//  ASRotatingMediaPageViewController.m
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/8/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import "ASMediaRotatingViewController.h"
+
+static NSTimeInterval const kDefaultOrientationAnimationDuration = 0.4;
+
+@interface ASMediaRotatingViewController ()
+@property (nonatomic, strong) UIViewController *viewController;
+@property (nonatomic, assign) UIDeviceOrientation previousOrientation;
+@end
+
+@implementation ASMediaRotatingViewController
+
+- (instancetype)initWithViewController:(UIViewController *)viewController
+{
+    self = [super init];
+    if (self) {
+        _viewController = viewController;
+    }
+    return self;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    [self addChildViewController:self.viewController];
+    [self.view addSubview:self.viewController.view];
+    self.viewController.view.frame = self.view.bounds;
+    self.viewController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self.viewController didMoveToParentViewController:self];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChangeNotification:) name:UIDeviceOrientationDidChangeNotification object:nil];
+    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+}
+
+- (void)orientationDidChangeNotification:(NSNotification *)notification
+{
+    [self updateOrientationAnimated:YES];
+}
+
+- (void)updateOrientationAnimated:(BOOL)animated
+{
+    CGAffineTransform transform;
+    CGRect frame;
+    NSTimeInterval duration = kDefaultOrientationAnimationDuration;
+
+    if([UIDevice currentDevice].orientation == self.previousOrientation)
+        return;
+
+    if((UIDeviceOrientationIsLandscape([UIDevice currentDevice].orientation) && UIDeviceOrientationIsLandscape(self.previousOrientation))
+       || (UIDeviceOrientationIsPortrait([UIDevice currentDevice].orientation) && UIDeviceOrientationIsPortrait(self.previousOrientation)))
+    {
+        duration *= 2;
+    }
+
+    if(([UIDevice currentDevice].orientation == UIDeviceOrientationPortrait)
+       || [self isParentSupportingInterfaceOrientation:(UIInterfaceOrientation)[UIDevice currentDevice].orientation])
+    {
+        transform = CGAffineTransformIdentity;
+    }
+    else
+    {
+        switch ([UIDevice currentDevice].orientation)
+        {
+            case UIDeviceOrientationLandscapeRight:
+                if(self.parentViewController.interfaceOrientation == UIInterfaceOrientationPortrait)
+                {
+                    transform = CGAffineTransformMakeRotation(-M_PI_2);
+                }
+                else
+                {
+                    transform = CGAffineTransformMakeRotation(M_PI_2);
+                }
+                break;
+
+            case UIDeviceOrientationLandscapeLeft:
+                if(self.parentViewController.interfaceOrientation == UIInterfaceOrientationPortrait)
+                {
+                    transform = CGAffineTransformMakeRotation(M_PI_2);
+                }
+                else
+                {
+                    transform = CGAffineTransformMakeRotation(-M_PI_2);
+                }
+                break;
+
+            case UIDeviceOrientationPortrait:
+                transform = CGAffineTransformIdentity;
+                break;
+
+            case UIDeviceOrientationPortraitUpsideDown:
+                transform = CGAffineTransformMakeRotation(M_PI);
+                break;
+
+            case UIDeviceOrientationFaceDown:
+            case UIDeviceOrientationFaceUp:
+            case UIDeviceOrientationUnknown:
+                return;
+        }
+    }
+
+    frame = self.viewController.view.frame;
+    [UIView animateWithDuration:(animated ? duration : 0)
+                     animations:^{
+                         self.viewController.view.transform = transform;
+                         self.viewController.view.frame = frame;
+                     }];
+
+    self.previousOrientation = [UIDevice currentDevice].orientation;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (BOOL)isParentSupportingInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
+{
+    switch(toInterfaceOrientation)
+    {
+        case UIInterfaceOrientationPortrait:
+            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskPortrait;
+
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskPortraitUpsideDown;
+
+        case UIInterfaceOrientationLandscapeLeft:
+            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskLandscapeLeft;
+
+        case UIInterfaceOrientationLandscapeRight:
+            return [self.parentViewController supportedInterfaceOrientations] & UIInterfaceOrientationMaskLandscapeRight;
+
+        case UIInterfaceOrientationUnknown:
+            return YES;
+    }
+}
+
+@end

--- a/ASMediaFocusManager/NSURL+ASMediaFocusManager.h
+++ b/ASMediaFocusManager/NSURL+ASMediaFocusManager.h
@@ -1,0 +1,15 @@
+//
+//  NSURL+ASMediaFocusManager.h
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/8/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSURL (ASMediaFocusManager)
+
+@property (nonatomic, assign, readonly) BOOL as_isVideoURL;
+
+@end

--- a/ASMediaFocusManager/NSURL+ASMediaFocusManager.m
+++ b/ASMediaFocusManager/NSURL+ASMediaFocusManager.m
@@ -1,0 +1,19 @@
+//
+//  NSURL+ASMediaFocusManager.m
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/8/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import "NSURL+ASMediaFocusManager.h"
+
+@implementation NSURL (ASMediaFocusManager)
+
+- (BOOL)as_isVideoURL
+{
+    NSString *extension = self.pathExtension.lowercaseString;
+    return ([extension isEqualToString:@"mp4"] || [extension isEqualToString:@"mov"]);
+}
+
+@end

--- a/ASMediaFocusManager/UIImage+ASMediaFocusManager.h
+++ b/ASMediaFocusManager/UIImage+ASMediaFocusManager.h
@@ -1,0 +1,15 @@
+//
+//  UIImage+ASMediaFocusManager.h
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/8/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (ASMediaFocusManager)
+
+@property (nonatomic, copy, readonly) UIImage *as_decodedImage;
+
+@end

--- a/ASMediaFocusManager/UIImage+ASMediaFocusManager.m
+++ b/ASMediaFocusManager/UIImage+ASMediaFocusManager.m
@@ -1,0 +1,72 @@
+//
+//  UIImage+ASMediaFocusManager.m
+//  ASMediaFocusExemple
+//
+//  Created by Kevin Lundberg on 6/8/15.
+//  Copyright (c) 2015 AutreSphere. All rights reserved.
+//
+
+#import "UIImage+ASMediaFocusManager.h"
+
+@implementation UIImage (ASMediaFocusManager)
+
+// Taken from https://github.com/rs/SDWebImage/blob/master/SDWebImage/SDWebImageDecoder.m
+- (UIImage *)as_decodedImage
+{
+    if (self.images) {
+        // Do not decode animated images
+        return self;
+    }
+
+    CGImageRef imageRef = self.CGImage;
+    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
+    CGRect imageRect = (CGRect){.origin = CGPointZero, .size = imageSize};
+
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
+
+    int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
+    BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
+                        infoMask == kCGImageAlphaNoneSkipFirst ||
+                        infoMask == kCGImageAlphaNoneSkipLast);
+
+    // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
+    // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
+    if (infoMask == kCGImageAlphaNone && CGColorSpaceGetNumberOfComponents(colorSpace) > 1) {
+        // Unset the old alpha info.
+        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
+
+        // Set noneSkipFirst.
+        bitmapInfo |= kCGImageAlphaNoneSkipFirst;
+    }
+    // Some PNGs tell us they have alpha but only 3 components. Odd.
+    else if (!anyNonAlpha && CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
+        // Unset the old alpha info.
+        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
+        bitmapInfo |= kCGImageAlphaPremultipliedFirst;
+    }
+
+    // It calculates the bytes-per-row based on the bitsPerComponent and width arguments.
+    CGContextRef context = CGBitmapContextCreate(NULL,
+                                                 imageSize.width,
+                                                 imageSize.height,
+                                                 CGImageGetBitsPerComponent(imageRef),
+                                                 0,
+                                                 colorSpace,
+                                                 bitmapInfo);
+    CGColorSpaceRelease(colorSpace);
+
+    // If failed, return undecompressed image
+    if (!context) return self;
+
+    CGContextDrawImage(context, imageRect, imageRef);
+    CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
+
+    CGContextRelease(context);
+
+    UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef scale:self.scale orientation:self.imageOrientation];
+    CGImageRelease(decompressedImageRef);
+    return decompressedImage;
+}
+
+@end

--- a/Example/ASMediaFocus/ASMediaFocusExemple-Info.plist
+++ b/Example/ASMediaFocus/ASMediaFocusExemple-Info.plist
@@ -35,9 +35,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Example/ASMediaFocusExemple.xcodeproj/project.pbxproj
+++ b/Example/ASMediaFocusExemple.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00DBB4761B223C0100A64046 /* ASMediaInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 00DBB4751B223C0100A64046 /* ASMediaInfo.m */; };
+		00DBB47E1B2607E900A64046 /* NSURL+ASMediaFocusManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 00DBB47D1B2607E900A64046 /* NSURL+ASMediaFocusManager.m */; };
+		00DBB4811B2608A100A64046 /* UIImage+ASMediaFocusManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 00DBB4801B2608A100A64046 /* UIImage+ASMediaFocusManager.m */; };
+		00DBB4841B260C4E00A64046 /* ASMediaRotatingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 00DBB4831B260C4E00A64046 /* ASMediaRotatingViewController.m */; };
 		4A0BC97B1AC9846F000904A2 /* 3f.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 4A0BC97A1AC9846F000904A2 /* 3f.mp4 */; };
 		4A0BC97E1AC9A684000904A2 /* ASVideoControlView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A0BC97D1AC9A684000904A2 /* ASVideoControlView.m */; };
 		4A0BC9801AC9A6AC000904A2 /* ASVideoControlView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4A0BC97F1AC9A6AC000904A2 /* ASVideoControlView.xib */; };
@@ -48,6 +52,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		00DBB4741B223C0100A64046 /* ASMediaInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMediaInfo.h; sourceTree = "<group>"; };
+		00DBB4751B223C0100A64046 /* ASMediaInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMediaInfo.m; sourceTree = "<group>"; };
+		00DBB47C1B2607E900A64046 /* NSURL+ASMediaFocusManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+ASMediaFocusManager.h"; sourceTree = "<group>"; };
+		00DBB47D1B2607E900A64046 /* NSURL+ASMediaFocusManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+ASMediaFocusManager.m"; sourceTree = "<group>"; };
+		00DBB47F1B2608A100A64046 /* UIImage+ASMediaFocusManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+ASMediaFocusManager.h"; sourceTree = "<group>"; };
+		00DBB4801B2608A100A64046 /* UIImage+ASMediaFocusManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+ASMediaFocusManager.m"; sourceTree = "<group>"; };
+		00DBB4821B260C4E00A64046 /* ASMediaRotatingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASMediaRotatingViewController.h; sourceTree = "<group>"; };
+		00DBB4831B260C4E00A64046 /* ASMediaRotatingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ASMediaRotatingViewController.m; sourceTree = "<group>"; };
 		3FD5F869702ABB49C37B7985 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		4A0BC97A1AC9846F000904A2 /* 3f.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = 3f.mp4; sourceTree = "<group>"; };
 		4A0BC97C1AC9A684000904A2 /* ASVideoControlView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASVideoControlView.h; sourceTree = "<group>"; };
@@ -236,20 +248,28 @@
 		4ABF0B0016A0575C0053040A /* ASMediaFocusManager */ = {
 			isa = PBXGroup;
 			children = (
+				4A2D149C16AD255800D3CE3D /* ASImageScrollView.h */,
+				4A2D149D16AD255800D3CE3D /* ASImageScrollView.m */,
 				4ABF0B0116A0575C0053040A /* ASMediaFocusController.h */,
 				4ABF0B0216A0575C0053040A /* ASMediaFocusController.m */,
 				4ABF0B1816A2E62E0053040A /* ASMediaFocusController.xib */,
 				4ABF0B0316A0575C0053040A /* ASMediaFocusManager.h */,
 				4ABF0B0416A0575C0053040A /* ASMediaFocusManager.m */,
+				00DBB4741B223C0100A64046 /* ASMediaInfo.h */,
+				00DBB4751B223C0100A64046 /* ASMediaInfo.m */,
+				00DBB4821B260C4E00A64046 /* ASMediaRotatingViewController.h */,
+				00DBB4831B260C4E00A64046 /* ASMediaRotatingViewController.m */,
+				4AFDA6A818C7179B00A1D0C4 /* ASTransparentView.h */,
+				4AFDA6A918C7179B00A1D0C4 /* ASTransparentView.m */,
 				4A70C03A1ACD4CC800828AA6 /* ASVideoBehavior.h */,
 				4A70C03B1ACD4CC800828AA6 /* ASVideoBehavior.m */,
-				4A2D149C16AD255800D3CE3D /* ASImageScrollView.h */,
-				4A2D149D16AD255800D3CE3D /* ASImageScrollView.m */,
-				4AFDA6A918C7179B00A1D0C4 /* ASTransparentView.m */,
-				4AFDA6A818C7179B00A1D0C4 /* ASTransparentView.h */,
 				4A0BC97C1AC9A684000904A2 /* ASVideoControlView.h */,
 				4A0BC97D1AC9A684000904A2 /* ASVideoControlView.m */,
 				4A0BC97F1AC9A6AC000904A2 /* ASVideoControlView.xib */,
+				00DBB47C1B2607E900A64046 /* NSURL+ASMediaFocusManager.h */,
+				00DBB47D1B2607E900A64046 /* NSURL+ASMediaFocusManager.m */,
+				00DBB47F1B2608A100A64046 /* UIImage+ASMediaFocusManager.h */,
+				00DBB4801B2608A100A64046 /* UIImage+ASMediaFocusManager.m */,
 				4A0BC98F1ACAB6CB000904A2 /* Resources */,
 			);
 			name = ASMediaFocusManager;
@@ -387,9 +407,13 @@
 				4A15DE3516776BE9004C6733 /* main.m in Sources */,
 				4A15DE3916776BE9004C6733 /* AppDelegate.m in Sources */,
 				4A0BC99D1ACAF13D000904A2 /* MediaCell.m in Sources */,
+				00DBB4841B260C4E00A64046 /* ASMediaRotatingViewController.m in Sources */,
 				4A7F15F21684635100ADC5D6 /* MainViewController.m in Sources */,
 				4ABF0B0516A0575C0053040A /* ASMediaFocusController.m in Sources */,
+				00DBB4761B223C0100A64046 /* ASMediaInfo.m in Sources */,
+				00DBB4811B2608A100A64046 /* UIImage+ASMediaFocusManager.m in Sources */,
 				4ABF0B0616A0575C0053040A /* ASMediaFocusManager.m in Sources */,
+				00DBB47E1B2607E900A64046 /* NSURL+ASMediaFocusManager.m in Sources */,
 				4A2D149E16AD255800D3CE3D /* ASImageScrollView.m in Sources */,
 				4A0BC97E1AC9A684000904A2 /* ASVideoControlView.m in Sources */,
 				4AFDA6AA18C7179B00A1D0C4 /* ASTransparentView.m in Sources */,

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,10 @@
+PODS:
+  - ASBPlayerScrubbing (0.1)
+
+DEPENDENCIES:
+  - ASBPlayerScrubbing
+
+SPEC CHECKSUMS:
+  ASBPlayerScrubbing: 0fc5e76aad6fdbcf14380734fb7f2c127cd28b66
+
+COCOAPODS: 0.37.1


### PR DESCRIPTION
ASMediaFocusManager now supports swiping between multiple photos/videos via a UIPageViewController. This commit involved some heavy refactoring of things, including moving rotation handling out into its own view controller that contains the UIPageViewController, moving lots of focus controller setup code into the focus controller itself, and some heavy deleage method restructuring to use a new model object that encapsulates all the necessary information for showing a single media element in each focus controller, since it's not possible to use the existing delegate methods to reconstruct all the necessary data in a reliable manner.

If there's anything that might need changing, let me know! I tried to keep things working as best as I could for each existing feature.
