### PR TITLE
Fix defocus animation for media view with custom layer mask

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -62,6 +62,8 @@
 @property (nonatomic, assign) BOOL addPlayIconOnVideo;
 // Image used to show a play icon on video thumbnails. Defaults to nil (uses internal image).
 @property (nonatomic, strong) UIImage *playImage;
+// Use media view screen shot on end focus animation. Usable if the media view as some kind of custom layer, for exemaple a mask layer. Defaults to NO
+@property (nonatomic, assign) BOOL useMediaViewScreenShotOnEndFocusAnimation;
 
 // Install focusing gesture on the specified array of views.
 - (void)installOnViews:(NSArray *)views;

--- a/ASMediaFocusManager/ASMediaFocusManager.h
+++ b/ASMediaFocusManager/ASMediaFocusManager.h
@@ -62,8 +62,8 @@
 @property (nonatomic, assign) BOOL addPlayIconOnVideo;
 // Image used to show a play icon on video thumbnails. Defaults to nil (uses internal image).
 @property (nonatomic, strong) UIImage *playImage;
-// Use media view screen shot on end focus animation. Usable if the media view as some kind of custom layer, for exemaple a mask layer. Defaults to NO
-@property (nonatomic, assign) BOOL useMediaViewScreenShotOnEndFocusAnimation;
+// Use media view screen shot on defocus animation. Usable if the media view as some kind of custom layer, for exemaple a mask layer. Defaults to NO.
+@property (nonatomic, assign) BOOL useMediaViewScreenshotOnDefocusAnimation;
 
 // Install focusing gesture on the specified array of views.
 - (void)installOnViews:(NSArray *)views;

--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -24,7 +24,7 @@ static CGFloat const kSwipeOffset = 100;
 @property (nonatomic, strong) ASMediaFocusController *focusViewController;
 @property (nonatomic, assign) BOOL isZooming;
 @property (nonatomic, strong) ASVideoBehavior *videoBehavior;
-@property (nonatomic, strong) UIImage *endFocusAnimationImage;
+@property (nonatomic, strong) UIImage *defocusAnimationImage;
 @end
 
 @implementation ASMediaFocusManager
@@ -44,7 +44,7 @@ static CGFloat const kSwipeOffset = 100;
         self.gestureDisabledDuringZooming = YES;
         self.isDefocusingWithTap = NO;
         self.addPlayIconOnVideo = YES;
-        self.useMediaViewScreenShotOnEndFocusAnimation = NO;
+        self.useMediaViewScreenshotOnDefocusAnimation = NO;
         self.videoBehavior = [ASVideoBehavior new];
     }
     
@@ -247,14 +247,14 @@ static CGFloat const kSwipeOffset = 100;
     viewController.mainImageView.image = image;
     viewController.mainImageView.contentMode = imageView.contentMode;
     
-    if (self.useMediaViewScreenShotOnEndFocusAnimation) {
-        // Take and save screen shot to use in the end focus animation
+    if (self.useMediaViewScreenshotOnDefocusAnimation) {
+        // Take and save screenshot to use in the end focus animation
         UIGraphicsBeginImageContextWithOptions(mediaView.frame.size, NO, [UIScreen mainScreen].scale);
         [mediaView drawViewHierarchyInRect:mediaView.bounds afterScreenUpdates:NO];
         UIImage *screenshotImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
         
-        self.endFocusAnimationImage = screenshotImage;
+        self.defocusAnimationImage = screenshotImage;
     }
     
     if ([self.delegate respondsToSelector:@selector(mediaFocusManager:cachedImageForView:)]) {
@@ -501,8 +501,8 @@ static CGFloat const kSwipeOffset = 100;
     
     [self.focusViewController defocusWillStart];
     
-    if (self.useMediaViewScreenShotOnEndFocusAnimation) {
-        self.focusViewController.mainImageView.image = self.endFocusAnimationImage;
+    if (self.useMediaViewScreenshotOnDefocusAnimation) {
+        self.focusViewController.mainImageView.image = self.defocusAnimationImage;
     }
     
     [UIView animateWithDuration:self.animationDuration
@@ -621,8 +621,8 @@ static CGFloat const kSwipeOffset = 100;
     offset = (gesture.direction == UISwipeGestureRecognizerDirectionUp?-kSwipeOffset:kSwipeOffset);
     contentView = self.focusViewController.mainImageView;
     
-    if (self.useMediaViewScreenShotOnEndFocusAnimation) {
-        self.focusViewController.mainImageView.image = self.endFocusAnimationImage;
+    if (self.useMediaViewScreenshotOnDefocusAnimation) {
+        self.focusViewController.mainImageView.image = self.defocusAnimationImage;
     }
     
     [UIView animateWithDuration:duration


### PR DESCRIPTION
If the media views (`UIImageView`) have some custom layer mask, the defocus animation with elastic becomes wrong.
The problem can be fixed by adding a screenshot from the media view to the `mainImageView` when the defocus animation is about to start.
A new flag was added (`useMediaViewScreenShotOnEndFocusAnimation`) to the `ASMediaFocusManager` to activate this behavior (default is disable).

Maybe You can consider to use the screenshot on defocus animation as default, because it smooths the animations and fix the problem with custom layers.