### PR TITLE
Fix warning : Conflicting return type in implementation of 'supported InterfaceOrientations'

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusController.m
+++ b/ASMediaFocusManager/ASMediaFocusController.m
@@ -94,7 +94,7 @@ static CGFloat const kDefaultControlMargin = 5;
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
 }
 
-- (NSUInteger)supportedInterfaceOrientations
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     return UIInterfaceOrientationMaskPortrait;
 }


### PR DESCRIPTION
ASMediaFocusController.m:97:1: Conflicting return type in implementation of 'supportedInterfaceOrientations': 'UIInterfaceOrientationMask' (aka 'enum UIInterfaceOrientationMask') vs 'NSUInteger' (aka 'unsigned int')