### PR TITLE
Fix remote image not being visible after download - Issue #44

### DIFF
--- a/ASMediaFocusManager/ASMediaFocusManager.m
+++ b/ASMediaFocusManager/ASMediaFocusManager.m
@@ -260,6 +260,7 @@ static CGFloat const kSwipeOffset = 100;
     {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             [self loadImageFromURL:url onImageView:viewController.mainImageView];
+            viewController.mainImageView.hidden = NO;
         });
     }
     


### PR DESCRIPTION
Fix issue  #44.

```installZoomView``` sets the ```mainImageView``` to hidden and no-one sets back the visibility, so after decode the requested image the visibility should be changed back to visible.

Tested with :
https://dl.dropboxusercontent.com/u/12595498/vlcsnap.png