### PR TITLE
Bumped spec to 0.7

### DIFF
--- a/ASMediaFocusManager.podspec
+++ b/ASMediaFocusManager.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ASMediaFocusManager"
-  s.version = "0.6"
+  s.version = "0.7"
   s.license = 'MIT'
   s.summary = "Animate your iOS image and video views to fullscreen on a simple tap."
   s.authors = {
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage = "https://github.com/autresphere/ASMediaFocusManager"
   s.source = {
     :git => "https://github.com/autresphere/ASMediaFocusManager.git",
-    :tag => "0.6"
+    :tag => s.version.to_s
   }
   s.platform = :ios, '6.0'
   s.source_files = 'ASMediaFocusManager/*.{h,m}'


### PR DESCRIPTION
This is a bump to the existing pod spec to the new version 0.7  

It's required that you add a tag to your repo `0.7` so we can submit the new spec to the `/Specs` repo with `pod trunk push ASMediaFocusManager.podspec`.
Spec was linted with `pod lib lint --allow-warnings` and it's ok.

If you need anything else, please say so 🍸  